### PR TITLE
Nagios plugins volume export

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM ubuntu:focal
 
-VOLUME /etc/icinga2
+VOLUME ["/etc/icinga2", "/usr/lib/nagios/plugins"]
 
 # Update system and install requirements
 RUN export DEBIAN_FRONTEND=noninteractive \
@@ -32,7 +32,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && rm -rf /var/lib/apt/lists/* \
     && /usr/lib/icinga2/prepare-dirs /etc/default/icinga2 \
     # Copy original configs in /etc/icinga2.dist/
-    && cp -a /etc/icinga2 /etc/icinga2.dist
+    && cp -a /etc/icinga2 /etc/icinga2.dist \
+    # Copy original nagios plugins to /usr/lib/nagios/plugins.dist
+    && cp -a /usr/lib/nagios/plugins /usr/lib/nagios/plugins.dist
 
 # Copy entrypoint.d, entrypoint.sh and healthcheck.sh scripts
 ADD entrypoint.d/ /entrypoint.d/

--- a/README.md
+++ b/README.md
@@ -231,10 +231,11 @@ Variables marked in **bold** are recommended to be adjusted according to your ne
 The following folders are configured and can be mounted as volumes.
 
 | Volume           | Description                    |
-| ---------------- | ------------------------------ |
-| /etc/icinga2     | Icinga 2 configuration folder. |
-| /var/lib/icinga2 | Icinga 2 library folder.       |
-| /var/log/icinga2 | Icinga 2 log folder.           |
+| ----------------------- | ------------------------------ |
+| /etc/icinga2            | Icinga 2 configuration folder. |
+| /var/lib/icinga2        | Icinga 2 library folder.       |
+| /var/log/icinga2        | Icinga 2 log folder.           |
+| /usr/lib/nagios/plugins | Nagios plugins folder.         |
 
 # Authors
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - /data/etc/icinga2:/etc/icinga2
       - /data/var/lib/icinga2:/var/lib/icinga2
       - /data/var/log/icinga2:/var/log/icinga2
+      - /data/usr/lib/nagios/plugins:/usr/lib/nagios/plugins
     ports:
       - "5665:5665"
     privileged: true

--- a/entrypoint.d/00-initial.sh
+++ b/entrypoint.d/00-initial.sh
@@ -16,3 +16,9 @@ chown -R nagios:nagios /var/lib/icinga2
 echo "Entrypoint: Create directory /var/log/icinga2."
 mkdir -p /var/log/icinga2
 chown -R nagios:adm /var/log/icinga2
+
+# Create directory /usr/lib/nagios/plugins and copy original plugins.
+echo "Entrypoint: Create directory /usr/lib/nagios/plugins."
+mkdir -p /usr/lib/nagios/plugins
+cp -a /usr/lib/nagios/plugins.dist/* /usr/lib/nagios/plugins/
+chown root:root /usr/lib/nagios/plugins


### PR DESCRIPTION
By default, icinga2 comes with a set of nagios plugin scripts. We want
to expose them to the host for easier modification and adding new plugins
later. This is why a new logic for exposing these plugins to the master
host has been added.